### PR TITLE
Properly close resource files

### DIFF
--- a/igorwriter/builtin_names.py
+++ b/igorwriter/builtin_names.py
@@ -1,9 +1,11 @@
-import os
+import importlib.resources
 
-DIR = os.path.join(os.path.dirname(__file__), 'builtins')
+BUILTIN_DIR = importlib.resources.files("igorwriter.builtins")
 
-
-operations = tuple(l.rstrip().lower() for l in open(os.path.join(DIR, 'operations.txt')).readlines())
-functions = tuple(l.rstrip().lower() for l in open(os.path.join(DIR, 'functions.txt')).readlines())
-keywords = tuple(l.rstrip().lower() for l in open(os.path.join(DIR, 'keywords.txt')).readlines())
-variables = tuple('k%d' % i for i in range(20)) + ('veclen',)
+with BUILTIN_DIR.joinpath("operations.txt").open("r") as f:
+    operations = tuple(ln.rstrip().lower() for ln in f.readlines())
+with BUILTIN_DIR.joinpath("functions.txt").open("r") as f:
+    functions = tuple(ln.rstrip().lower() for ln in f.readlines())
+with BUILTIN_DIR.joinpath("keywords.txt").open("r") as f:
+    keywords = tuple(ln.rstrip().lower() for ln in f.readlines())
+variables = tuple("k%d" % i for i in range(20)) + ("veclen",)


### PR DESCRIPTION
I've noticed some warnings about the resource files not being properly closed:

```
ResourceWarning: unclosed file <_io.TextIOWrapper name='./.venv/lib/python3.13/site-packages/igorwriter/builtins/operations.txt' mode='r' encoding='utf-8'>
    operations = tuple(l.rstrip().lower() for l in open(os.path.join(DIR, 'operations.txt')).readlines())
  Enable tracemalloc to get traceback where the object was allocated.
  See https://docs.pytest.org/en/stable/how-to/capture-warnings.html#resource-warnings for more info.
```

I replaced open calls with context managers so that they are now properly closed.